### PR TITLE
2.5.3

### DIFF
--- a/assets/docs/CDElements.scss
+++ b/assets/docs/CDElements.scss
@@ -57,4 +57,25 @@ Interactive elements are either indicated by their position (e.g. in the navigat
 
 The uniform foot bar closes the pages. It contains a copyright notice as well as links to the “legal notice” and “further legal information”.
 
+## Favicon
+
+Don't forget the favicon before putting the website in production. The favicon ressources are located in the `/build/img/ico/` directory. Include them with the adequate code in your index file:
+
+```html
+<link rel="shortcut icon" href="build/img/ico/favicon.ico">
+<link rel="apple-touch-icon" sizes="57x57" href="build/img/ico/apple-touch-icon-57x57.png">
+<link rel="apple-touch-icon" sizes="114x114" href="build/img/ico/apple-touch-icon-114x114.png">
+<link rel="apple-touch-icon" sizes="72x72" href="build/img/ico/apple-touch-icon-72x72.png">
+<link rel="apple-touch-icon" sizes="144x144" href="build/img/ico/apple-touch-icon-144x144.png">
+<link rel="apple-touch-icon" sizes="60x60" href="build/img/ico/apple-touch-icon-60x60.png">
+<link rel="apple-touch-icon" sizes="120x120" href="build/img/ico/apple-touch-icon-120x120.png">
+<link rel="apple-touch-icon" sizes="76x76" href="build/img/ico/apple-touch-icon-76x76.png">
+<link rel="icon" type="image/png" href="build/img/ico/favicon-96x96.png" sizes="96x96">
+<link rel="icon" type="image/png" href="build/img/ico/favicon-16x16.png" sizes="16x16">
+<link rel="icon" type="image/png" href="build/img/ico/favicon-32x32.png" sizes="32x32">
+<meta name="msapplication-TileColor" content="#ffffff">
+<meta name="msapplication-TileImage" content="img/ico/mstile-144x144.png">
+<meta name="msapplication-config" content="img/ico/browserconfig.xml">
+```
+
 */

--- a/assets/examples/functions.scss
+++ b/assets/examples/functions.scss
@@ -21,18 +21,34 @@ category: Content Modules - Functions
 
 <span class="label label-admin">FLEX</span>
 
-The "Print" icon, with a link to the print version, can be integrated into every page (except the home page). It is positioned at the top right of the content column. A click on the icon opens the browser’s or operating system’s print dialog.
+The "Print" icon, with a link to the print version, can be integrated into every page (except the home page). It is positioned at the top right of the content column. A click on the icon opens the print dialog window.
+
+You can target a specific element to isolate and print by adding a `data-print="ID"` on the wrapper and setting `onclick="$.printPreview.printPreview(ID)"` on the print button. If a `data-title` attribute is set on the wrapper, it will be displayed as the title of the printed page.
 
 <br>
 <div class="alert alert-warning">
   **2.5.3:**
 
   - change the `onclick="window.print()"` by `onclick="$.printPreview.printPreview()"`
+  - add an optional target to the printPreview function: `onclick="$.printPreview.printPreview('target id')"`
 </div>
 
 
 ```html_example
 <a href="#" onclick="$.printPreview.printPreview()" class="icon icon--before icon--print"></a>
+
+<br><br>
+```
+
+With a specific target:
+
+```html_example
+<div class="example" data-print="example-print" data-title="Big pretty Title">
+  <h4>We only want to print this</h4>
+  <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quos labore non cum eligendi cumque, ipsa, repudiandae consequatur aut ducimus, molestiae nesciunt consectetur laborum pariatur accusamus in aspernatur quod quae possimus!</p>
+</div>
+
+<a href="#" onclick="$.printPreview.printPreview('example-print')" class="icon icon--before icon--print"></a>
 
 <br><br>
 ```

--- a/assets/examples/standard-element.scss
+++ b/assets/examples/standard-element.scss
@@ -142,7 +142,7 @@ To have this grey background, add a `well` wrapper around your content.
   <div class="row">
     <div class="col-sm-8 col-sm-offset-2">
 
-      <div class="well">
+      <div class="well clearfix">
         <h2>Big image</h2>
         <br>
         <figure>
@@ -157,7 +157,7 @@ To have this grey background, add a `well` wrapper around your content.
 
       <br>
 
-      <div class="well">
+      <div class="well clearfix">
         <h2>Small image</h2>
         <br>
         <figure class="pull-left">
@@ -178,7 +178,7 @@ To have this grey background, add a `well` wrapper around your content.
         <a href="#" class="icon icon--after icon--external">External link</a>
       </div>
 
-      <div class="well">
+      <div class="well clearfix">
         <h2>Tiny image</h2>
         <br>
         <figure class="pull-left">

--- a/assets/examples/standard-element.scss
+++ b/assets/examples/standard-element.scss
@@ -134,7 +134,13 @@ category: Content Modules - Standard elements
 
 The info box is a "text and image" element that has a gray background. It can be integrated into the running text body in order highlight additional information.
 
-To have this grey background, add a `well` wrapper around your content.
+To have this grey background, add a `.well .clearfix` wrapper around your content.
+
+<br>
+<div class="alert alert-warning">
+  **2.5.3:**
+  - add a `.clearfix` class to the `.well` wrapper
+</div>
 
 ```html_example
 <!-- Use normal `container` instead of `container-fluid` -->

--- a/assets/js/autocomplete.js
+++ b/assets/js/autocomplete.js
@@ -38,11 +38,7 @@
   $('.form-search').append('<button class="icon icon--search icon--before"></button>');
 
   $('body').on('click', '[data-form-search-clear]', function () {
-    $(this).siblings('.search-field').focus().val('');
-  });
-
-  $('body').on('click', function () {
-    $('#search-field').val('');
+    $('#search-field').val('').focus(); // clear search field and refocus it
   });
 
 }) (jQuery, (typeof searchData === 'undefined' ? false : searchData));

--- a/assets/js/print.js
+++ b/assets/js/print.js
@@ -18,13 +18,22 @@
 
   $.printPreview = {
 
-    printPreview: function() {
+    printPreview: function(element) {
       var $body = $('body'),
           $container = $('.container-main'),
           footnoteLinks = "",
           linksIndex = 0;
 
       $body.find('.nav-mobile, .drilldown, .nav-main, .header-separator, .nav-service, .nav-lang, .form-search, .yamm--select, header > div:first-child, footer, .alert, .icon--print, .social-sharing, form, .nav-process, .carousel-indicators, .carousel-control, .breadcrumb, .pagination-container').remove();
+
+      // if an element is passed, we want it to be the only thing to print out
+      if (element) {
+        element = $('[data-print=' + element + ']');
+        var header = $('header');
+            title = element.attr('data-title') ? '<h1>' + element.attr('data-title') + '</h1>' : '';
+        $container.addClass('print-element').html('').append(header).append(title).append(element);
+      }
+
       $body.addClass('print-preview');
 
       $container.prepend('<div class="row" id="print-settings">'+

--- a/assets/js/shame.js
+++ b/assets/js/shame.js
@@ -13,6 +13,8 @@
 
   $(document).ready(function () {
     var id;
+    var isCarouselified = false;
+    var isCollapsified = false;
     carouselify();
     collapsify();
 
@@ -29,20 +31,21 @@
     function carouselify() {
       var $tabFocus = $(".tab-focus"),
           focusIndex = 0;
-      if($tabFocus && $(window).width() < 767 ) {
+      if($tabFocus && $(window).width() <= 767 && !isCarouselified ) {
+        isCarouselified = true;
         $tabFocus.each(function () {
           var $that = $(this),
               itemIndex = -1;
           focusIndex += 1;
           $that.attr('id', 'tab-focus-'+focusIndex);
-          $that.next(".nav-tabs").hide();
+          $that.next(".nav-tabs").hide().removeClass('nav-tabs-focus').addClass('focus');
           $that.addClass('carousel slide').removeClass('tab-content tab-border');
           $that.wrapInner( "<div class='carousel-inner'></div>");
           $that.prepend( "<ol class=\"carousel-indicators\"></ol>" );
 
           $that.find('.tab-pane').each(function () {
             itemIndex += 1;
-            $(this).removeClass('tab-pane fade in active').addClass('item');
+            $(this).removeClass('tab-pane in active').addClass('item');
             $that.find('.carousel-indicators').append("<li data-target=\"#tab-focus-"+focusIndex+"\" data-slide-to=\""+itemIndex+"\" class=\"\"></li>");
           });
           $that.find('.item:first').addClass('active');
@@ -50,16 +53,18 @@
 
           $that.append( "<a class=\"left carousel-control icon icon--before icon--less\" href=\"#tab-focus-"+focusIndex+"\" data-slide=\"prev\"></a><a class=\"right carousel-control icon icon--before icon--greater\" href=\"#tab-focus-"+focusIndex+"\" data-slide=\"next\"></a>" );
         });
-      } else if($tabFocus) {
+      } else if($tabFocus && $(window).width() > 767 && isCarouselified) {
+        isCarouselified = false;
         $tabFocus.each(function () {
           var $that = $(this);
           focusIndex -= 1;
-          $that.next(".nav-tabs").show();
+          $that.attr('id', '');
+          $that.next(".focus").addClass('nav-tabs-focus').removeClass('focus').css('display', 'flex'); // we can't use .show() because it should be a flex wrapper
           $that.removeClass('carousel slide').addClass('tab-content tab-border');
           $that.find( "ol.carousel-indicators" ).remove();
 
           $that.find('.item').each(function () {
-            $(this).addClass('tab-pane fade').removeClass('item');
+            $(this).addClass('tab-pane').removeClass('item');
             $(this).css('height', 'auto');
           });
           $that.find('.tab-pane:first-child').addClass('active in');
@@ -74,10 +79,11 @@
     }
 
     function collapsify() {
-      var $navTab = $(".nav-tabs"),
+      var $navTab = $(".nav-tabs:not(.focus)"),
           $collapsify = $(".collapsify"),
           linkIndex = 0;
-      if($navTab && $(window).width() < 767 ) {
+      if($navTab && $(window).width() <= 767 && !isCollapsified ) {
+        isCollapsified = true;
         $navTab.not('.tab-focus').each(function (){
           var $that = $(this);
           $that.removeClass("nav-tabs").addClass('collapsify');
@@ -96,7 +102,8 @@
           });
           //$that.find('a:first-child').removeClass('collapse-closed').next('.collapse').addClass('in');
         });
-      } else if($collapsify) {
+      } else if($collapsify && $(window).width() > 767 && isCollapsified) {
+        isCollapsified = false;
         $collapsify.each(function (){
           var $that = $(this);
           $that.addClass("nav-tabs").removeClass('collapsify');

--- a/assets/js/tabs.js
+++ b/assets/js/tabs.js
@@ -15,19 +15,24 @@
   var interval = 3000;
   var tabCarousel = setInterval(nextSlide, interval);
 
-  $('.tab-content.tab-focus, .nav-tabs.nav-tabs-focus').hover(function(e){
+  $(document).on({
+    mouseenter: function () {
       clearInterval(tabCarousel);
-  }, function(e){
+    },
+    mouseleave: function () {
       tabCarousel = setInterval( nextSlide, interval);
-  });
+    }
+  }, ".tab-content.tab-focus, .nav-tabs.nav-tabs-focus");
 
   function nextSlide() {
-    var tabs = $('.nav-tabs-focus.nav-tabs > li'),
-        active = tabs.filter('.active'),
-        next = active.next('li'),
-        toClick = next.length ? next.find('a') : tabs.eq(0).find('a');
+    if ($('.nav-tabs-focus.nav-tabs > li').length) {
+      var tabs = $('.nav-tabs-focus.nav-tabs > li'),
+          active = tabs.filter('.active'),
+          next = active.next('li'),
+          toClick = next.length ? next.find('a') : tabs.eq(0).find('a');
 
-    toClick.tab('show');
+      toClick.tab('show');
+    }
   }
 
 }) (jQuery);

--- a/assets/pages/detail.twig
+++ b/assets/pages/detail.twig
@@ -6,7 +6,7 @@
 {% block content %}
   <div class="col-md-8">
       <div class="visible-xs visible-sm">
-        <p><a href="#context-sidebar" class="icon icon--before icon--root">Context sidebar</a></p>
+        <p><a href="#context-sidebar" class="icon icon--before icon--root hidden-print">Context sidebar</a></p>
       </div>
       <a href="#" onclick="$.printPreview.printPreview()" class="icon icon--before icon--print pull-right"></a>
       <h1 class="text-inline">This is the page title, and it can be really quite long.</h1>
@@ -110,7 +110,7 @@
       <br>
 
       <!-- Contextual information -->
-      <a name="context-sidebar"></a>
+      <a name="context-sidebar" class="hidden-print"></a>
 
       <!-- Nav tabs -->
       <ul class="nav nav-tabs">

--- a/assets/pages/forms.twig
+++ b/assets/pages/forms.twig
@@ -7,7 +7,7 @@
   <div class="col-md-8">
 
     <div class="visible-xs visible-sm">
-      <p><a href="#context-sidebar" class="icon icon--before icon--root">Context sidebar</a></p>
+      <p><a href="#context-sidebar" class="icon icon--before icon--root hidden-print">Context sidebar</a></p>
     </div>
 
     <nav class="nav-process">

--- a/assets/pages/layout.twig
+++ b/assets/pages/layout.twig
@@ -449,7 +449,7 @@
 
                   <!-- Tab panes -->
                   <div class="tab-content tab-border">
-                    <div class="tab-pane active" id="contact">
+                    <div class="tab-pane active" id="contact" title="Contact">
                       <address itemprop="address" itemscope="itemscope" itemtype="http://data-vocabulary.org/Address">
                         <strong itemprop="name">UNO-Mission New York</strong>
                         <span>Permanent Mission of Switzerland to the UN</span><br>
@@ -476,7 +476,7 @@
                       closed</p>
                       <p><a href="#" class="icon icon--before icon--print">Print contact infos</a></p>
                     </div>
-                    <div class="tab-pane" id="map">
+                    <div class="tab-pane" id="map" title="Map">
                       <h3>UNO-Mission New York</h3>
                       <p>633, Third Avenue<br>
                       New York, NY10017-6706</p>

--- a/assets/pages/layout.twig
+++ b/assets/pages/layout.twig
@@ -407,7 +407,7 @@
                 <ul>
                   <!-- the .list-emphasis class is optionnal -->
                   <li class="list-emphasis">
-                    <a href="#">Drinks</a>
+                    <span>Drinks</span>
                     <ul>
                       <!-- add the .list-sub class if the list has some animated sub-lists -->
                       <li class="list-sub"><a href="#">Mineral water</a>
@@ -421,13 +421,14 @@
                           </ul>
                         </nav>
                       </li>
-                      <li class="active">Wine <span class="sr-only"></span></li>
+                      <li class="active" aria-selected="true"><span>Wine<span class="sr-only"> active</span></span></li>
                       <li><a href="#">Beer</a></li>
                       <li><a href="#">Spirits</a></li>
                     </ul>
                   </li>
                 </ul>
               </nav>
+
             </div>
           </div>
         {% endblock %}

--- a/assets/pages/layout.twig
+++ b/assets/pages/layout.twig
@@ -448,7 +448,7 @@
                   </ul>
 
                   <!-- Tab panes -->
-                  <div class="tab-content tab-border">
+                  <div class="tab-content tab-border" data-print="contact" data-title="Contact info">
                     <div class="tab-pane active" id="contact" title="Contact">
                       <address itemprop="address" itemscope="itemscope" itemtype="http://data-vocabulary.org/Address">
                         <strong itemprop="name">UNO-Mission New York</strong>
@@ -474,7 +474,7 @@
                       09.00-12.00 AM</p>
                       <p>Saturday and Sunday<br>
                       closed</p>
-                      <p><a href="#" class="icon icon--before icon--print">Print contact infos</a></p>
+                      <p><a href="#" onclick="$.printPreview.printPreview('contact')" class="icon icon--before icon--print">Print contact infos</a></p>
                     </div>
                     <div class="tab-pane" id="map" title="Map">
                       <h3>UNO-Mission New York</h3>

--- a/assets/pages/layout.twig
+++ b/assets/pages/layout.twig
@@ -438,7 +438,7 @@
               <div class="col-md-4">
 
                 <!-- Contextual information -->
-                <a name="context-sidebar"></a>
+                <a name="context-sidebar" class="hidden-print"></a>
 
                 <!-- Nav tabs -->
                   <ul class="nav nav-tabs">

--- a/assets/pages/publications.twig
+++ b/assets/pages/publications.twig
@@ -5,7 +5,7 @@
 {% block content %}
     <div class="col-md-8">
       <div class="visible-xs visible-sm">
-        <p><a href="#context-sidebar" class="icon icon--before icon--root">Context sidebar</a></p>
+        <p><a href="#context-sidebar" class="icon icon--before icon--root hidden-print">Context sidebar</a></p>
       </div>
       <article>
         <a href="#" class="icon icon--before icon--less hidden-print">Back to Overview</a>

--- a/assets/pages/publications.twig
+++ b/assets/pages/publications.twig
@@ -9,7 +9,7 @@
       </div>
       <article>
         <a href="#" class="icon icon--before icon--less hidden-print">Back to Overview</a>
-        <button type="button" class="btn btn-link pull-right"><span class="icon icon--print"></span></button>
+        <a href="#" onclick="$.printPreview.printPreview()" class="icon icon--before icon--print pull-right"></a>
         <h1>Lorem ipsum dolor sit amet, consectetur adipisicing elit.</h1>
         <br>
         <div class="row">

--- a/assets/sass/admin-mixins.scss
+++ b/assets/sass/admin-mixins.scss
@@ -47,7 +47,7 @@
   background: -webkit-gradient(linear,left top,left bottom,color-stop(0%,#e8e8e8),color-stop(61%,#f7f7f7),color-stop(89%,#f7f7f7),color-stop(91%,#f5f5f5),color-stop(95%,#ececec),color-stop(100%,#d7d7d7));
   background: -webkit-linear-gradient(top,#e8e8e8 0%,#f7f7f7 61%,#f7f7f7 89%,#f5f5f5 91%,#ececec 95%,#d7d7d7 100%);
   background: -o-linear-gradient(top,#e8e8e8 0%,#f7f7f7 61%,#f7f7f7 89%,#f5f5f5 91%,#ececec 95%,#d7d7d7 100%);
-  background: linear-gradient(top,#e8e8e8 0%,#f7f7f7 61%,#f7f7f7 89%,#f5f5f5 91%,#ececec 95%,#d7d7d7 100%);
+  background: linear-gradient(to bottom,#e8e8e8 0,#f7f7f7 61%,#f7f7f7 89%,#f5f5f5 91%,#ececec 95%,#d7d7d7 100%);
 }
 
 @mixin gradient-light {

--- a/assets/sass/bootstrap.scss
+++ b/assets/sass/bootstrap.scss
@@ -14,6 +14,7 @@
 @import 'bootstrap-variables';
 
 // Core variables and mixins
+@import '../../bower_components/bootstrap-sass-official/assets/stylesheets/bootstrap/_variables.scss';
 @import '../../bower_components/bootstrap-sass-official/assets/stylesheets/bootstrap/_mixins.scss';
 
 // Reset and dependencies

--- a/assets/sass/components/collapse.scss
+++ b/assets/sass/components/collapse.scss
@@ -67,6 +67,10 @@ Add `.collapsed` to link for it to change the icon direction when collapsing.
 
 */
 
+.collapse {
+  @include clearfix;
+}
+
 .collapsing, .collapse.in {
   margin-left: 1.2em;
 }

--- a/assets/sass/components/focus.scss
+++ b/assets/sass/components/focus.scss
@@ -87,7 +87,7 @@ Please be careful about the length of the text in the tabs, the height is fixed.
 
   <!-- focus tabs -->
   <ul class="nav nav-tabs nav-tabs-focus nav-justified">
-    <li class="active"><a href="#home" data-toggle="tab">Title longer than usual</a></li>
+    <li class="active"><a href="#home" data-toggle="tab">Title longer than usual and even a bit longer that it should be. More than a tweet!</a></li>
     <li><a href="#profile" data-toggle="tab">Title 2</a></li>
     <li><a href="#messages" data-toggle="tab">Das ist der Megateaser</a></li>
     <li><a href="#settings" data-toggle="tab">Lorem ipsum dolor sit amet</a></li>
@@ -101,6 +101,7 @@ Please be careful about the length of the text in the tabs, the height is fixed.
 @media only screen and (min-width: $screen-sm-min) {
 
 .nav-tabs.nav-tabs-focus {
+  display: flex;
   position: relative;
   border-top: 1px solid $silver;
   border-right: 1px solid $silver;
@@ -120,18 +121,26 @@ Please be careful about the length of the text in the tabs, the height is fixed.
 }
 
 .nav-tabs.nav-tabs-focus li {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
   border: none;
   border-left: 1px solid $silver;
   border-bottom: none !important;
   position: relative;
+  .oldie &,
+  .ie9 & {
+    width: 1%;
+    a {height: 69px;}
+  }
   &:first-child, &:first-child:not(.active):hover a {border-left: none;}
   a {
+    flex-grow: 1;
     background: $smoke;
-    height: 69px;
     display: block;
+    position: relative;
     border: none;
     box-sizing: border-box !important;
-    border-bottom: 1px solid $silver;
     padding-bottom: 10px;
     font-size: 15px;
     line-height: 1.1em;
@@ -139,17 +148,30 @@ Please be careful about the length of the text in the tabs, the height is fixed.
     border-radius: 0;
     color: $night-rider;
     overflow: hidden;
+    &:after {
+      content: '';
+      height: 1px;
+      width: 100%;
+      display: block;
+      position: absolute;
+      left: 0;
+      bottom: 0;
+      background: $silver;
+    }
   }
-  a:hover, a:focus  {
-    height: 69px;
+  &.active a, &.active:hover a {
+    padding-bottom: 10px !important;
+  }
+  a:hover, a:focus, &.active a  {
     border: none;
-    border-bottom: 3px solid $venetian-red;
     color: $black;
+    &:after {
+      background: $venetian-red;
+      height: 3px;
+    }
   }
   &.active a, &.active a:hover, &.active a:focus {
-    border: none;
-    padding-bottom: 10px !important;
-    border-bottom: 3px solid $venetian-red;
+    border: none !important;
     background: $gainsboro;
     color: $black;
   }

--- a/assets/sass/components/focus.scss
+++ b/assets/sass/components/focus.scss
@@ -162,7 +162,7 @@ Please be careful about the length of the text in the tabs, the height is fixed.
   &.active a, &.active:hover a {
     padding-bottom: 10px !important;
   }
-  a:hover, a:focus, &.active a  {
+  a:hover, &.active a  {
     border: none;
     color: $black;
     &:after {
@@ -170,7 +170,7 @@ Please be careful about the length of the text in the tabs, the height is fixed.
       height: 3px;
     }
   }
-  &.active a, &.active a:hover, &.active a:focus {
+  &.active a, &.active a:hover {
     border: none !important;
     background: $gainsboro;
     color: $black;

--- a/assets/sass/components/navigation.scss
+++ b/assets/sass/components/navigation.scss
@@ -353,7 +353,7 @@ Add `<div class="overlay"></div>` at the end of the `body` tag to display the gr
     > a {
       height: 70px;
       @include gradient-menu;
-      max-width: 140px;
+      max-width: 110px;
       color: $coal;
       font-size: 0.8em;
       line-height: 1.2;
@@ -929,8 +929,8 @@ Navigation below the content level on a smartphone with links to the home page, 
           <a href="#" class="icon icon--before icon--less visible-xs">Back to parent</a>
           <a href="#" class="icon icon--before icon--less"><span class="sr-only">Back to </span>Comestible Goods</a>
           <ul>
-            <li class="list-emphasis active">
-              <span>Drinks</span><span class="sr-only">active</span>
+            <li class="list-emphasis">
+              <span>Drinks</span>
               <ul>
                 <!-- add the .list-sub class if the list has some animated sub-lists -->
                 <li class="list-sub"><a href="#">Mineral water</a>
@@ -944,7 +944,7 @@ Navigation below the content level on a smartphone with links to the home page, 
                     </ul>
                   </nav>
                 </li>
-                <li><a href="#">Wine</a></li>
+                <li class="active" aria-selected="true">Wine<span class="sr-only"> active</span></li>
                 <li><a href="#">Beer</a></li>
                 <li><a href="#">Spirits</a></li>
               </ul>
@@ -965,38 +965,44 @@ Navigation below the content level on a smartphone with links to the home page, 
     // adding this padding for compensating the padding we removed from .drilldown
     padding-left: 15px;
     padding-right: 15px;
-    li.list-emphasis {
-      padding: 0;
-      border: 0;
-      > a,
-      > span:first-child {
-        border-bottom: 1px solid $coal;
+  }
+  li.list-emphasis {
+    padding: 0;
+    border: 0;
+    > a,
+    > span:first-child {
+      border-bottom: 1px solid $coal;
+      display: block;
+      color: $black;
+      font-weight: 700;
+      padding: 10px 0;
+      @media screen and (max-width: $screen-xs-max) {
+        padding: 10px;
+      }
+      position: relative;
+      &:before {
+        content: '';
         display: block;
-        color: $black;
-        font-weight: 700;
-        padding: 10px 0;
-        position: relative;
-        &:before {
-          content: '';
-          display: block;
-          position: absolute;
-          top: 0;
-          left: -15px;
-          width: 5px;
-          height: 100%;
+        position: absolute;
+        top: 0;
+        left: -15px;
+        width: 5px;
+        height: 100%;
+        @media screen and (max-width: $screen-xs-max) {
+          left: 0;
         }
       }
-      &.active {
-        padding: 0;
-        border: 0;
+    }
+    &.active {
+      padding: 0;
+      border: 0;
+      &:before {
+        background: none;
+      }
+      > a,
+      > span {
         &:before {
-          background: none;
-        }
-        > a,
-        >span {
-          &:before {
-            background: $venetian-red;
-          }
+          background: $venetian-red;
         }
       }
     }
@@ -1012,7 +1018,7 @@ Navigation below the content level on a smartphone with links to the home page, 
     padding: 0px 10px 8px 10px;
     border-bottom: 1px solid $silver;
     @media only screen and (min-width: $screen-sm-min) {font-size: 11px;}
-    &:first-child { border: 1px solid $silver; }
+    &:first-child { border-top: 3px solid $silver; }
     &:before {
       font-size: 20px;
       position: relative;
@@ -1038,10 +1044,16 @@ Navigation below the content level on a smartphone with links to the home page, 
     &.active {
       color: $black;
       padding: 10px 0;
+      @media screen and (max-width: $screen-xs-max) {
+        padding: 10px;
+      }
       position: relative;
       border-bottom: 1px solid $silver;
       &:before {
         background: $venetian-red;
+        @media screen and (max-width: $screen-xs-max) {
+          left: 0;
+        }
       }
       > a {
         padding: 0;
@@ -1051,6 +1063,9 @@ Navigation below the content level on a smartphone with links to the home page, 
         }
       }
       .nav-mobile & { padding-bottom: 40px; }
+      ul {
+        padding-left: 25px;
+      }
     }
     a {
       color: $empress;
@@ -1089,10 +1104,6 @@ Navigation below the content level on a smartphone with links to the home page, 
     li a,
     ul ul li:first-child a {
       color: $cerulean;
-    }
-    .icon--less:not(.drilldown-back),
-    .icon--power {
-      background: none;
     }
     .icon--power {
       border-top: 1px solid $silver;

--- a/assets/sass/components/slideshow.scss
+++ b/assets/sass/components/slideshow.scss
@@ -26,6 +26,15 @@ The slideshow uses the jQuery plugin ([Blueimp Bootstrap Image Gallery](https://
 
 The slideshow component is not compliant with accessibility standards. If you need to be compliant, please consider other options for presenting your content.
 
+<br>
+<div class="alert alert-warning">
+  **2.5.3:**
+
+  - switched order between the `<small>` and `<div>` elements inside of `.carousel-controls` container
+  - removed `.pull-right` class to those same 2 elements
+  - added `.pull-right` class to `.carousel-controls` element
+</div>
+
 ```html_example
 <div class="row">
   <div class="col-sm-6 col-sm-offset-3">
@@ -51,11 +60,11 @@ The slideshow component is not compliant with accessibility standards. If you ne
           </div>
         </div>
       </div>
-      <div class="carousel-controls">
-        <div class="pull-right">
+      <div class="carousel-controls pull-right">
+        <small><span id="carousel-index">1</span> of <span id="carousel-total"></span></small>
+        <div>
           <a class="left icon icon--before icon--less" href="#carousel-slideshow" data-slide="prev" aria-label="previous"></a><a class="right icon icon--before icon--greater" href="#carousel-slideshow" data-slide="next" aria-label="next"></a>
         </div>
-        <small class="pull-right"><span id="carousel-index">1</span> of <span id="carousel-total"></span></small>
       </div>
 
     </div>
@@ -113,8 +122,13 @@ The slideshow component is not compliant with accessibility standards. If you ne
   }
 
   .carousel-controls {
+    > div {
+      display: inline-block;
+    }
     small {
-      margin: 23px 15px 0 0;
+      display: inline-block;
+      vertical-align: top;
+      margin: 25px 15px 0 0;
       color: $coal;
     }
     a {

--- a/assets/sass/components/tab.scss
+++ b/assets/sass/components/tab.scss
@@ -100,6 +100,7 @@ ul.nav-tabs {
 
 .nav-tabs>li.active>a:focus {
   border-top: 3px solid $venetian-red;
+  border-bottom-color: $white;
 }
 
 .nav-tabs>li.active:not(:first-child)>a:focus {

--- a/assets/sass/layout/forms.scss
+++ b/assets/sass/layout/forms.scss
@@ -224,6 +224,8 @@ legend {
 }
 
 .form-group {
+  @include clearfix;
+
   .control-label {
     padding-top: 4px;
   }

--- a/assets/sass/print/print-general.scss
+++ b/assets/sass/print/print-general.scss
@@ -99,11 +99,11 @@ unbedingt Reihenfolge behalten
   .tab-content>.tab-pane {
     display: block !important;
     visibility: visible;
-  }
-  .tab-pane + .tab-pane {
     border-top: 1px dashed #6d6d6d;
+    margin-bottom: 15px;
     &:before {
-      content: '(next tab)';
+      content: attr(title) ' tab:';
+      opacity: .6;
     }
   }
   .tab-content, .tab-content.tab-border {

--- a/assets/sass/print/print-general.scss
+++ b/assets/sass/print/print-general.scss
@@ -4,9 +4,7 @@ Formatierung Chrome und IE
 unbedingt Reihenfolge behalten
 */
 
-.print-preview {
-  display: block !important;
-
+@mixin print-preview {
   // Hide elements
   .nav-mobile,
   .drilldown,
@@ -57,11 +55,6 @@ unbedingt Reihenfolge behalten
     padding: 0 15px;
   }
 
-  // Adjust breaking page elements
-  table {
-    page-break-before: always;
-  }
-
 
   header {
     margin: 40px 0;
@@ -103,8 +96,14 @@ unbedingt Reihenfolge behalten
     max-height: auto !important;
   }
   .tab-content>.tab-pane {
-    display: block;
+    display: block !important;
     visibility: visible;
+  }
+  .tab-pane + .tab-pane {
+    border-top: 1px dashed #6d6d6d;
+    &:before {
+      content: '(next tab)';
+    }
   }
   .tab-content, .tab-content.tab-border {
     padding: 0;
@@ -129,8 +128,14 @@ unbedingt Reihenfolge behalten
   #print-settings .pagination-container {display: block !important;}
 }
 
+.print-preview {
+  display: block !important;
+  @include print-preview;
+}
+
 @media print {
-  @extend .print-preview;
+  @include print-preview;
+
   #print-settings,
   .icon--print {display: none !important;}
 }

--- a/assets/sass/print/print-general.scss
+++ b/assets/sass/print/print-general.scss
@@ -32,6 +32,7 @@ unbedingt Reihenfolge behalten
 
   // Force show elements
   [class*="hidden-"] {display: inline-block !important;}
+  .hidden-print {display: none !important;}
 
   // Force white background for preview
   header {

--- a/assets/sass/print/print-general.scss
+++ b/assets/sass/print/print-general.scss
@@ -78,7 +78,7 @@ unbedingt Reihenfolge behalten
     color: blue !important;
     text-decoration: underline;
   }
-  a:after{
+  a:not([name="context-sidebar"]):after{
     content:" (" attr(href) ") " !important;
     font-size:0.8em;
     font-weight:normal;

--- a/assets/sass/print/print-general.scss
+++ b/assets/sass/print/print-general.scss
@@ -132,6 +132,10 @@ unbedingt Reihenfolge behalten
 .print-preview {
   display: block !important;
   @include print-preview;
+
+  .print-element {
+    padding: 0 25px;
+  }
 }
 
 @media print {


### PR DESCRIPTION
- #375 add `.clearfix` class to the infobox element to avoid overflowing elements when floated **!markup**
- #374 remove clearing of search-field when clicking on body element, enhance its clear button
- #371 remove the <kbd>p</kbd> key shortcut to show the print view
- add `.hidden-print` class to *content-sidebar* anchors
- #372 #370  fix print styles
- #357 add optional parameter to the `printPreview()` function **!markup** [-> see doc](http://swiss.github.io/styleguide/content_modules_-_functions.html#a-print)
- #373 fix nav-page-list element to behave correctly on mobile
- set `.clearfix` class to collapse element to avoid issues with first-child heading
- change max-width of nav-main element from 140px to 110px
- #376 fix slideshow carousel-controls element to make it work with bigger numbers **!markup**
- #368 fix missing print function on publications page
- #380 add info about favicons in the CDelements page
- #367 #344 fix markup change in js for the focus and tabs elements
- fix various visual issues with tabs (background-color, padding, focus state)