### PR TITLE
fix fonts paths in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,10 +10,10 @@
     "./build/css/*.css",
     "./build/js/vendors.min.js",
     "./build/js/main.js",
-    "./build/font/*.eot",
-    "./build/font/*.svg",
-    "./build/font/*.ttf",
-    "./build/font/*.woff"
+    "./build/fonts/*.eot",
+    "./build/fonts/*.svg",
+    "./build/fonts/*.ttf",
+    "./build/fonts/*.woff"
   ],
   "ignore": [
     "**/.*",


### PR DESCRIPTION
The fonts paths in the ```bower.json``` do not comply with the real filenames in the ```./build/``` directory. I've fixed this.