### PR TITLE
Resolve Bug #400 No more unnecessary line wrap, and adding classes for other number of steps

### DIFF
--- a/assets/sass/components/progression.scss
+++ b/assets/sass/components/progression.scss
@@ -24,8 +24,8 @@ Process navigation is used in connection with forms that are spread over several
 
 ```html_example
 
-<nav class="nav-process nav-process-steps-5"> 
-<!--  Adjust the classname 'nav-process-steps-5' to the number of pages you have (2 to 10). -->
+<nav class="nav-process nav-process-steps-4"> 
+<!--  Adjust the classname 'nav-process-steps-4' to the number of pages you have (2 to 10). -->
   <ul>
     <li>
       <a href="#">Step 1</a>
@@ -39,16 +39,13 @@ Process navigation is used in connection with forms that are spread over several
     <li class="disabled">
       <a href="#">Step 4</a>
     </li>
-    <li class="disabled">
-      <a href="#">Step 5</a>
-    </li>
 
   </ul>
 </nav>
 ```
 */
 
-.nav-process { 
+.nav-process {
   width: 100%;
   height: 30px;
   ul {
@@ -59,7 +56,7 @@ Process navigation is used in connection with forms that are spread over several
   li a {
     display: block;
     height: 6px;
-    width: 24.2%; // not needed with, left in for backwards compatibility
+    width: 24.2%; // only for backwards compatibility
     float: left;
     background: $light-grey;
     margin: 0 0.5%;

--- a/assets/sass/components/progression.scss
+++ b/assets/sass/components/progression.scss
@@ -23,7 +23,9 @@ category: Navigation modules - Content Navigation
 Process navigation is used in connection with forms that are spread over several pages. The active process stage is marked in red. The previous steps are clickable and lead the user back to the selected process stage.
 
 ```html_example
-<nav class="nav-process">
+
+<nav class="nav-process nav-process-steps-5"> 
+<!--  Adjust the classname 'nav-process-steps-5' to the number of pages you have (2 to 10). -->
   <ul>
     <li>
       <a href="#">Step 1</a>
@@ -37,12 +39,16 @@ Process navigation is used in connection with forms that are spread over several
     <li class="disabled">
       <a href="#">Step 4</a>
     </li>
+    <li class="disabled">
+      <a href="#">Step 5</a>
+    </li>
+
   </ul>
 </nav>
 ```
 */
 
-.nav-process {
+.nav-process { 
   width: 100%;
   height: 30px;
   ul {
@@ -53,7 +59,7 @@ Process navigation is used in connection with forms that are spread over several
   li a {
     display: block;
     height: 6px;
-    width: 24.2%;
+    width: 24.2%; // not needed with, left in for backwards compatibility
     float: left;
     background: $light-grey;
     margin: 0 0.5%;
@@ -101,12 +107,13 @@ Process navigation is used in connection with forms that are spread over several
   li.disabled a:hover:after, li.disabled a:active:after, li.disabled a:focus:after {border-left-color: $light-grey;}
   li:last-child a:after {display: none;}
   li.active a {
+    position: relative;
+    left: -0.2%;
     margin-top: -2px;
-    margin-left: .4%;
-    margin-right: .6%;
     height: 10px;
     padding-top: 2px;
   }
+  
   li.active a:after {
     border-width: 5px;
     right: -5px;
@@ -114,4 +121,11 @@ Process navigation is used in connection with forms that are spread over several
   li.active a:before {
     border-width: 5px;
   }
+
+  // create the widths for different amounts of steps
+  @for $i from 2 through 10 {
+    &.nav-process-steps-#{$i} li a {
+      width: ((100% - 1% * ($i - 1)) / $i) // For each step there is a -1% margin, minus one, because no margins on the far left and on the far right
+    }
+  } 
 }

--- a/assets/sass/components/progression.scss
+++ b/assets/sass/components/progression.scss
@@ -23,7 +23,6 @@ category: Navigation modules - Content Navigation
 Process navigation is used in connection with forms that are spread over several pages. The active process stage is marked in red. The previous steps are clickable and lead the user back to the selected process stage.
 
 ```html_example
-
 <nav class="nav-process nav-process-steps-4"> 
 <!--  Adjust the classname 'nav-process-steps-4' to the number of pages you have (2 to 10). -->
   <ul>
@@ -39,7 +38,6 @@ Process navigation is used in connection with forms that are spread over several
     <li class="disabled">
       <a href="#">Step 4</a>
     </li>
-
   </ul>
 </nav>
 ```
@@ -110,7 +108,6 @@ Process navigation is used in connection with forms that are spread over several
     height: 10px;
     padding-top: 2px;
   }
-  
   li.active a:after {
     border-width: 5px;
     right: -5px;
@@ -118,7 +115,6 @@ Process navigation is used in connection with forms that are spread over several
   li.active a:before {
     border-width: 5px;
   }
-
   // create the widths for different amounts of steps
   @for $i from 2 through 10 {
     &.nav-process-steps-#{$i} li a {


### PR DESCRIPTION
Past: The active class added some extra margin to the active item, which was overriding the property margin for a:first-child { margin-left: 0}, a:last-child {margin-right: 0}.

Now: Resolved by doing this with relative positioning instead and increased the shift from 0.1% to 0.2%.

New: Also added classes to make this component usable with 2 to 10 steps, by adding the class nav-process-steps-N (where N is the number of steps). Which is documented in the code example.
