### PR TITLE
working progression for forms up to ten steps, proper overflow

### DIFF
--- a/assets/docs/Accessibility.scss
+++ b/assets/docs/Accessibility.scss
@@ -11,6 +11,6 @@ Additional Information:
 
 [Web Content Accessibility Guidelines (WCAG) 2.0](http://www.w3.org/TR/WCAG20/)
 
-[The Guidelines of the Confederation (P028)](http://www.isb.admin.ch/themen/standards/alle/03237/)
+[The Guidelines of the Confederation (P028)](https://www.isb.admin.ch/isb/de/home/ikt-vorgaben/prozesse-methoden/p028-richtlinien_bund_gestaltung_barrierefreie_internetangebote.html)
 
 */

--- a/assets/sass/components/progression.scss
+++ b/assets/sass/components/progression.scss
@@ -23,7 +23,8 @@ category: Navigation modules - Content Navigation
 Process navigation is used in connection with forms that are spread over several pages. The active process stage is marked in red. The previous steps are clickable and lead the user back to the selected process stage.
 
 ```html_example
-<nav class="nav-process">
+<nav class="nav-process nav-process-steps-4"> 
+<!--  Adjust the classname 'nav-process-steps-4' to the number of pages you have (2 to 10). -->
   <ul>
     <li>
       <a href="#">Step 1</a>
@@ -35,7 +36,7 @@ Process navigation is used in connection with forms that are spread over several
       <a href="#">Step 3</a>
     </li>
     <li class="disabled">
-      <a href="#">Step 4</a>
+      <a href="#" disabled>Step 4</a>
     </li>
   </ul>
 </nav>
@@ -49,32 +50,42 @@ Process navigation is used in connection with forms that are spread over several
     padding: 0;
     margin: 0;
   }
-  li {margin: 0;}
-  li a {
+  li {
     display: block;
     height: 6px;
-    width: 24.2%;
+    width: 24.2%; // only for backwards compatibility
     float: left;
     background: $light-grey;
     margin: 0 0.5%;
-    color: $black;
     text-align: center;
     font-size: 13px;
     line-height: 35px;
     position: relative;
   }
-  li.active a, li a:hover, li a:active, li a:focus {
+  li a {
+    margin-top: -0.3em; // negative margin to extend the clickable area to the decorative bar
+    padding-top: 1.1em;
+    width: 100%;
+    display: block;
+    color: $black;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    overflow-x: hidden;
+  }
+  li.active, li:hover, li:focus {
     background: $venetian-red;
     font-weight: 700;
   }
-  li.disabled a:hover, li.disabled a:active, li.disabled a:focus {
+  li.disabled:hover {
     background: $light-grey;
+  }
+  li.disabled a:hover, li.disabled a:active, li.disabled a:focus {
     cursor: not-allowed;
     text-decoration: none;
   }
-  li:first-child a {margin-left: 0;}
-  li:last-child a {margin-right: 0;}
-  li a:before {
+  li:first-child {margin-left: 0;}
+  li:last-child {margin-right: 0;}
+  li:before {
     content: '';
     position: absolute;
     left: 0;
@@ -85,8 +96,8 @@ Process navigation is used in connection with forms that are spread over several
     border-left: 3px solid $white;
     border-bottom: 3px solid transparent;
   }
-  li:first-child a:before {display: none;}
-  li a:after {
+  li:first-child:before {display: none;}
+  li:after {
     content: '';
     position: absolute;
     right: -3px;
@@ -97,21 +108,27 @@ Process navigation is used in connection with forms that are spread over several
     border-left: 3px solid $light-grey;
     border-bottom: 3px solid transparent;
   }
-  li.active a:after, li a:hover:after, li a:active:after, li a:focus:after {border-left-color: $venetian-red;}
-  li.disabled a:hover:after, li.disabled a:active:after, li.disabled a:focus:after {border-left-color: $light-grey;}
-  li:last-child a:after {display: none;}
-  li.active a {
+  li.active:after, li:hover:after {border-left-color: $venetian-red;}
+  li.disabled:hover:after {border-left-color: $light-grey;}
+  li:last-child:after {display: none;}
+  li.active {
+    position: relative;
+    left: -0.2%;
     margin-top: -2px;
-    margin-left: .4%;
-    margin-right: .6%;
     height: 10px;
     padding-top: 2px;
   }
-  li.active a:after {
+  li.active:after {
     border-width: 5px;
     right: -5px;
   }
-  li.active a:before {
+  li.active:before {
     border-width: 5px;
   }
+  // create the widths for different amounts of steps
+  @for $i from 2 through 10 {
+    &.nav-process-steps-#{$i} li {
+      width: ((100% - 1% * ($i - 1)) / $i) // For each step there is a -1% margin, minus one, because no margins on the far left and on the far right
+    }
+  } 
 }


### PR DESCRIPTION
The current implementation of the form progression has several issues:

* The predefined width only works for four steps
* when setting the first or last item to .active it wraps to a new line (see #400) 
* when not enough space the link text overflows and also wraps to new lines

This can get extremely messy:
![bildschirmfoto 2015-11-27 um 22 41 55](https://cloud.githubusercontent.com/assets/194364/11448417/1f75632e-9558-11e5-948a-82b8f1eaf54f.png)

# Solution:

* Including new classnames that allow to pick a certain amount of steps without having to calculate the widths manually (nav-process-steps-2 to nav-process-steps-10)
* Moving the borders and pseudoelements to the `li` instead of the link. This allows to use overflow on the `a`. It no longer extends beyond the width

# Drawback:

* This solution has a drawback: As the decorative elements are no longer part of the link `a`, the :focus and :active pseudo-classes will no longer display the red bar, but I do not think that matters as much. I don't think there is better solution, at least no without having to adjust the markup.

With the new solution the same html will look like this:

![bildschirmfoto 2015-11-27 um 22 42 03](https://cloud.githubusercontent.com/assets/194364/11448449/f26733d4-9558-11e5-9789-3c0bda5421a0.png)

Only tested on OS X, with the latest Chrome, Firefox and Safari.

(http://swiss.github.io/styleguide/navigation_modules_-_content_navigation.html#c-process-navigation) 

