### PR TITLE
Corrected CSS include order that failed when using as bower package

### DIFF
--- a/assets/sass/layout/checkboxes.scss
+++ b/assets/sass/layout/checkboxes.scss
@@ -45,7 +45,6 @@ Checkboxes are used when one or more elements are to be selected from a predefin
   input {
     position: absolute;
     left: -999999999%;
-    display: none;
   }
   label {
     position: relative;

--- a/bower.json
+++ b/bower.json
@@ -1,13 +1,15 @@
 {
   "name": "swiss-styleguide",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "homepage": "http://swiss.github.io/styleguide",
   "authors": "Antistatique.net",
   "description": "Swiss Admin Styleguide",
   "license": "MIT",
   "main": [
     "./styleguide/index.html",
-    "./build/css/*.css",
+    "./build/css/vendors.css",
+    "./build/css/admin.css",
+    "./build/css/print.css",
     "./build/js/vendors.min.js",
     "./build/js/main.js",
     "./build/fonts/*.eot",


### PR DESCRIPTION
When the swiss-styleguide is used as a bower package that is then packaged with gulp, the CSS is included/concatenated in the order that the bower.json dictates. If there is a wildcard, the file system order is taken (e.g. alphabetical order). But the vendor.css needs to be included before the admin.css.