### PR TITLE
Fix Html in markdown

### DIFF
--- a/src/locales/de/content.yml
+++ b/src/locales/de/content.yml
@@ -42,7 +42,7 @@ teaser:
 
       *** Accessibility
 
-      Das Titelformat H3 in den Teaser-Beispielen ist keine allgemeine Vorgabe. Das Format H1, H2, H3 etc. richtet sich nach der Gewichtung des Titels in der Struktur der <section> oder der Seite.
+      Das Titelformat H3 in den Teaser-Beispielen ist keine allgemeine Vorgabe. Das Format H1, H2, H3 etc. richtet sich nach der Gewichtung des Titels in der Struktur der `<section>` oder der Seite.
 
     release: |
       **3.0.0**
@@ -58,7 +58,7 @@ teaser:
 
       *** Accessibility
 
-      Das Titelformat H3 in den Teaser-Beispielen ist keine allgemeine Vorgabe. Das Format H1, H2, H3 etc. richtet sich nach der Gewichtung des Titels in der Struktur der <section> oder der Seite.
+      Das Titelformat H3 in den Teaser-Beispielen ist keine allgemeine Vorgabe. Das Format H1, H2, H3 etc. richtet sich nach der Gewichtung des Titels in der Struktur der `<section>` oder der Seite.
 
     release: |
       **3.1.0**

--- a/src/locales/de/docs.yml
+++ b/src/locales/de/docs.yml
@@ -8,7 +8,7 @@ index:
 
     ## Ausnahmen
 
-    Ausnahmen vom Webdesign Bund sind für Kampagnen- und Partner-Websites möglich. Sie müssen von der Konferenz der Generalsekretäre der Departemente (GSK) genehmigt werden. Entsprechende Anträge sind bei der <a href="http://intranet.bk.admin.ch/themen/02268/02270/index.html?lang=de">Fachstelle CD Bund</a>  der Bundeskanzlei einzureichen.
+    Ausnahmen vom Webdesign Bund sind für Kampagnen- und Partner-Websites möglich. Sie müssen von der Konferenz der Generalsekretäre der Departemente (GSK) genehmigt werden. Entsprechende Anträge sind bei [Fachstelle CD Bund](http://intranet.bk.admin.ch/themen/02268/02270/index.html?lang=de) der Bundeskanzlei einzureichen.
 
     ## Benutzerfreundliche und barrierefreie Websites
 
@@ -75,7 +75,7 @@ index:
 
     ## Überarbeitung und Weiterentwicklung
 
-    Die Entwicklung der Richtlinien, die Issues und Releases sind auf Github dokumentiert: <a href="http://github.com/swiss/styleguide">Richtlinien für das Webdesign Bund</a>. Fehlermeldungen und Anregungen sind dort einzugeben. Dafür ist ein Konto bei Github nötig. Anfragen dazu bitte per Mail an <a href="mailto:webforum@bk.admin.ch">Webforum Bund</a>.
+    Die Entwicklung der Richtlinien, die Issues und Releases sind auf Github dokumentiert: [Richtlinien für das Webdesign Bund](http://github.com/swiss/styleguide). Fehlermeldungen und Anregungen sind dort einzugeben. Dafür ist ein Konto bei Github nötig. Anfragen dazu bitte per Mail an <a href="mailto:webforum@bk.admin.ch">Webforum Bund</a>.
 
     Das Webforum Bund überprüft die Webrichtlinien periodisch auf Aktualität und Konformität mit den Entwicklungen im Web.
 
@@ -89,14 +89,14 @@ accessibility:
   title: Barrierefreiheit
   intro: |
 
-    Laut dem <a href="https://www.admin.ch/opc/de/classified-compilation/20002658/index.html#a14">Behindertengleichstellungsgesetz (BehiG)Art. 14</a> müssen Dienstleistungen der Bundesverwaltung im Internet Sehbehinderten ohne erschwerende Bedingungen zugänglich sein. Erfüllt ist diese Vorgabe, wenn eine Website die Konformitätsbedingungen gemäss WCAG 2.0 entspricht und die Konformitätsstufe AA erreicht.
+    Laut dem [Behindertengleichstellungsgesetz (BehiG) Art. 14](https://www.admin.ch/opc/de/classified-compilation/20002658/index.html#a14) müssen Dienstleistungen der Bundesverwaltung im Internet Sehbehinderten ohne erschwerende Bedingungen zugänglich sein. Erfüllt ist diese Vorgabe, wenn eine Website die Konformitätsbedingungen gemäss WCAG 2.0 entspricht und die Konformitätsstufe AA erreicht.
 
     Weiterführende Informationen:
 
-      - <a href="https://www.admin.ch/opc/de/classified-compilation/20002658/index.html">Behindertengleichstellungsgesetz (BehiG)</a>
-      - <a href="https://www.isb.admin.ch/isb/de/home/ikt-vorgaben/prozesse-methoden/p028-richtlinien_bund_gestaltung_barrierefreie_internetangebote.html">P028 - Richtlinien des Bundes für die Gestaltung von barrierefreien Internetangeboten</a>
-      - <a href="http://www.w3.org/TR/WCAG20/">Web Content Accessibility Guidelines (WCAG) 2.0</a>
-      - <a href="http://www.w3.org/TR/wai-aria/">Accessible Rich Internet Applications (WAI-ARIA) 1.0</a>
+      - [Behindertengleichstellungsgesetz (BehiG)](https://www.admin.ch/opc/de/classified-compilation/20002658/index.html)
+      - [P028 - Richtlinien des Bundes für die Gestaltung von barrierefreien Internetangeboten](https://www.isb.admin.ch/isb/de/home/ikt-vorgaben/prozesse-methoden/p028-richtlinien_bund_gestaltung_barrierefreie_internetangebote.html)
+      - [Web Content Accessibility Guidelines (WCAG) 2.0](http://www.w3.org/TR/WCAG20/)
+      - [Accessible Rich Internet Applications (WAI-ARIA) 1.0](http://www.w3.org/TR/wai-aria/)
 
     ## Gute Praxis
 
@@ -156,14 +156,14 @@ accessibility:
 
       ### Color Contrast Analyzer
 
-      <a href="https://www.paciellogroup.com/resources/contrastanalyser/">Color Contrast Analyzer</a> ist ein Werkzeug, das dabei hilft, den Kontrast zwischen Vorder- und Hintergrundfarbe zu analysieren.
+      [Color Contrast Analyzer](https://www.paciellogroup.com/resources/contrastanalyser/) ist ein Werkzeug, das dabei hilft, den Kontrast zwischen Vorder- und Hintergrundfarbe zu analysieren.
 
-    Die Web Accessibility Initiative (WAI) des World Wide Web Consortiums (W3C) bietet eine <a href=" https://www.w3.org/WAI/ER/tools/index.html">ausführliche Liste</a> von Tools zur Accessibility-Evaluation an.
+    Die Web Accessibility Initiative (WAI) des World Wide Web Consortiums (W3C) bietet eine [ausführliche Liste](https://www.w3.org/WAI/ER/tools/index.html) von Tools zur Accessibility-Evaluation an.
 
     ## Weitere Informationen und Kontakt
 
     Geschäftsstelle E-Accessibility Bund (2015-2017)
-    <a href="mailto:markus.riesch@gs-edi.admin.ch">Markus Riesch</a> Tel. +41584625463
+    [Markus Riesch](mailto:markus.riesch@gs-edi.admin.ch) Tel. +41584625463
 
 basic-grid:
   title: Grundraster und Seitentypen
@@ -348,7 +348,7 @@ guidelines:
 
     ## Installation
 
-    Die Installationsangaben für die Verwendung der Richtlinien in einem Projekt finden sich auf <a href="https://github.com/swiss/styleguide#the-swiss-federal-administration-on-the-internet">Github</a>
+    Die Installationsangaben für die Verwendung der Richtlinien in einem Projekt finden sich auf [Github](href="https://github.com/swiss/styleguide#the-swiss-federal-administration-on-the-internet).
 
 
 header-footer:

--- a/src/locales/de/navigation.yml
+++ b/src/locales/de/navigation.yml
@@ -230,7 +230,7 @@ content-navigation:
     release: |
       **2.1.8**
 
-      - added ` <span class="sr-only">current page</span>` and `aria-disabled="true"` for accessibility
+      - added `<span class="sr-only">current page</span>` and `aria-disabled="true"` for accessibility
       - added `title`to empty link (link only with icon)
       - added `.clearfix`and `.pull-left` inside of `.pagination-container
   anchor-links:

--- a/src/locales/en/navigation.yml
+++ b/src/locales/en/navigation.yml
@@ -229,7 +229,7 @@ content-navigation:
     release: |
       **2.1.8**
 
-      - added ` <span class="sr-only">current page</span>` and `aria-disabled="true"` for accessibility
+      - added `<span class="sr-only">current page</span>` and `aria-disabled="true"` for accessibility
       - added `title`to empty link (link only with icon)
       - added `.clearfix`and `.pull-left` inside of `.pagination-container
   anchor-links:

--- a/src/locales/fr/docs.yml
+++ b/src/locales/fr/docs.yml
@@ -8,7 +8,7 @@ index:
 
     ## Exceptions
 
-    Des exceptions du design web de la Confédération sont possibles pour les sites Internet de campagne et partenaires. Elles doivent être approuvées par la Conférence des secrétaires généraux des départements (CSG). Les demandes correspondantes doivent être soumises au <a href="http://intranet.bk.admin.ch/themen/02268/02270/index.html?lang=de">Service Identité visuelle de la Confédération</a> de la Chancellerie fédérale.
+    Des exceptions du design web de la Confédération sont possibles pour les sites Internet de campagne et partenaires. Elles doivent être approuvées par la Conférence des secrétaires généraux des départements (CSG). Les demandes correspondantes doivent être soumises au [Service Identité visuelle de la Confédération](http://intranet.bk.admin.ch/themen/02268/02270/index.html?lang=de) de la Chancellerie fédérale.
 
     ## Sites Internet conviviaux et accessibles
 
@@ -75,7 +75,7 @@ index:
 
     ## Révision et développement
 
-    Le développement des lignes directrices, les thèmes et les communiqués sont documentés sur Github: <a href="http://github.com/swiss/styleguide">Lignes directrices pour le design web de la Confédération</a>. Il convient d’y saisir les signalements d’erreurs et suggestions. Cela nécessite un compte sur Github. Les demandes à ce sujet doivent être adressées par e-mail au <a href="mailto:webforum@bk.admin.ch">Webforum de la Confédération</a>.
+    Le développement des lignes directrices, les thèmes et les communiqués sont documentés sur Github: [Lignes directrices pour le design web de la Confédération](http://github.com/swiss/styleguide). Il convient d’y saisir les signalements d’erreurs et suggestions. Cela nécessite un compte sur Github. Les demandes à ce sujet doivent être adressées par e-mail au [Webforum de la Confédération](mailto:webforum@bk.admin.ch).
 
     Le Webforum de la Confédération vérifie périodiquement les lignes directrices web en vue de leur actualité et conformité avec les évolutions du web.
 
@@ -87,14 +87,14 @@ accessibility:
   title: Accessibilité
   intro: |
 
-    Selon la <a href="https://www.admin.ch/opc/de/classified-compilation/20002658/index.html#a14">Loi sur l’égalité pour les handicapés (LHand) art. 14</a>, l’accès aux prestations sur Internet de l’administration fédérale ne doit pas être rendu difficile aux handicapés de la vue. Cette exigence est respectée lorsqu’un site Internet satisfait aux conditions de conformité des WCAG 2.0 et qu’il atteint le niveau de conformité AA.
+    Selon la [Loi sur l’égalité pour les handicapés (LHand) art. 14](https://www.admin.ch/opc/de/classified-compilation/20002658/index.html#a14), l’accès aux prestations sur Internet de l’administration fédérale ne doit pas être rendu difficile aux handicapés de la vue. Cette exigence est respectée lorsqu’un site Internet satisfait aux conditions de conformité des WCAG 2.0 et qu’il atteint le niveau de conformité AA.
 
     Informations complémentaires:
 
-      - <a href="https://www.admin.ch/opc/fr/classified-compilation/20002658/index.html">Loi sur l’égalité pour les handicapés (LHand)</a>
-      - <a href="https://www.isb.admin.ch/isb/fr/home/ikt-vorgaben/prozesse-methoden/p028-richtlinien_bund_gestaltung_barrierefreie_internetangebote.html">P028 - Directives de la Confédération pour l’aménagement de sites Internet facilement accessibles</a>
-      - <a href="http://www.w3.org/TR/WCAG20/">Web Content Accessibility Guidelines (WCAG) 2.0</a>
-      - <a href="http://www.w3.org/TR/wai-aria/">Accessible Rich Internet Applications (WAI-ARIA) 1.0</a>
+      - [Loi sur l’égalité pour les handicapés (LHand)](https://www.admin.ch/opc/fr/classified-compilation/20002658/index.html)
+      - [P028 - Directives de la Confédération pour l’aménagement de sites Internet facilement accessibles](https://www.isb.admin.ch/isb/fr/home/ikt-vorgaben/prozesse-methoden/p028-richtlinien_bund_gestaltung_barrierefreie_internetangebote.html)
+      - [Web Content Accessibility Guidelines (WCAG) 2.0](http://www.w3.org/TR/WCAG20/)
+      - [Accessible Rich Internet Applications (WAI-ARIA) 1.0](http://www.w3.org/TR/wai-aria/)
 
     ## Bonnes pratiques
 
@@ -153,13 +153,13 @@ accessibility:
 
       ### Color Contrast Analyzer
 
-      <a href="https://www.paciellogroup.com/resources/contrastanalyser/">Color Contrast Analyzer</a> est un outil qui permet d’analyser le contraste entre la couleur du premier plan et celle de l’arrière-plan.
+      [Color Contrast Analyzer](https://www.paciellogroup.com/resources/contrastanalyser/) est un outil qui permet d’analyser le contraste entre la couleur du premier plan et celle de l’arrière-plan.
 
-    La Web Accessibility Initiative (WAI) du World Wide Web Consortiums (W3C) propose une <a href=" https://www.w3.org/WAI/ER/tools/index.html">liste complète</a> d’outils d’évaluation de l’accessibilité.
+    La Web Accessibility Initiative (WAI) du World Wide Web Consortiums (W3C) propose une [liste complète](https://www.w3.org/WAI/ER/tools/index.html) d’outils d’évaluation de l’accessibilité.
 
     ## Informations supplémentaires et contact
 
-    Service E-Accessibility de la Confédération (2015-2017) <a href="mailto:markus.riesch@gs-edi.admin.ch">Markus Riesch</a> Tél. +41584625463
+    Service E-Accessibility de la Confédération (2015-2017) [Markus Riesch](mailto:markus.riesch@gs-edi.admin.ch) Tél. +41584625463
 
 basic-grid:
   title: Grille de base et types de pages
@@ -185,7 +185,7 @@ basic-grid:
 
     ### Navigation de gauche
 
-    La sous-navigation dans la colonne de gauche de la zone de contenu est une «navigation de déplacement» qui indique toujours les options de la page actuelle. Elle se compose de trois zones: l’en-tête de navigation avec le titre de la page actuelle, un lien «Retour» vers le niveau de navigation supérieur et des liens vers les sous-pages. Le comportement est décrit sur la page d’élément <a href="/fr/hierarchical-navigation.html#01-hierarchical-navigation-04-page-navigation-list">Liste de navigation latérale (sous-navigation de gauche)</a>.
+    La sous-navigation dans la colonne de gauche de la zone de contenu est une «navigation de déplacement» qui indique toujours les options de la page actuelle. Elle se compose de trois zones: l’en-tête de navigation avec le titre de la page actuelle, un lien «Retour» vers le niveau de navigation supérieur et des liens vers les sous-pages. Le comportement est décrit sur la page d’élément [Liste de navigation](/fr/hierarchical-navigation.html#01-hierarchical-navigation-04-page-navigation-list) latérale (sous-navigation de gauche)</a>.
 
 
     ### Zone de contenu
@@ -342,7 +342,7 @@ guidelines:
 
     ## Installation
 
-    Les informations d’installation pour l’utilisation des lignes directrices dans le cadre d’un projet peuvent être consultées sur <a href="https://github.com/swiss/styleguide#the-swiss-federal-administration-on-the-internet">Github</a>
+    Les informations d’installation pour l’utilisation des lignes directrices dans le cadre d’un projet peuvent être consultées sur [Github](https://github.com/swiss/styleguide#the-swiss-federal-administration-on-the-internet)
 
 
 header-footer:

--- a/src/locales/fr/navigation.yml
+++ b/src/locales/fr/navigation.yml
@@ -126,7 +126,7 @@ header:
   accessibility-navigation:
     title: Navigation accessible
     help: |
-      La navigation accessible est placée directement après la balise <body>. Elle est nécessaire pour offrir aux utilisateurs un accès rapide à certains services grâce à des raccourcis clavier. La navigation accessible n’est **pas visible**.
+      La navigation accessible est placée directement après la balise `<body>`. Elle est nécessaire pour offrir aux utilisateurs un accès rapide à certains services grâce à des raccourcis clavier. La navigation accessible n’est **pas visible**.
 
       Remarque: Selon le navigateur utilisé, les liens d'accessibilité dans l'example s'affichent seulement après avoir appuyé tab plusieurs fois. Ceci est dû au fait que la page webguidelines utilise une navigation accessible elle-même.
     release: |


### PR DESCRIPTION
This PR ensures that all HTML tags which are not meant to be interpreted as such are surrounded by backticks. Moreover, it changes links to markdown syntax wherever possible.