### PR TITLE
contact-box alignment #516

### DIFF
--- a/src/assets/sass/components/contact-box.scss
+++ b/src/assets/sass/components/contact-box.scss
@@ -1,6 +1,12 @@
-address {
-  strong {
-    font-weight: normal;
-    display: block;
+div[data-print="contact-info"] {
+  address {
+    padding: 10px 0px;
+    strong {
+      font-weight: normal;
+      display: block;
+    }
+  }
+  p a.icon:before{
+    padding-right: 33px;
   }
 }


### PR DESCRIPTION
fixes #516
I did not align the "Print contact infos" because it's below the opening hours and isn't part of the contact info.