### PR TITLE
607 print mode links

### DIFF
--- a/src/assets/sass/print/print-general.scss
+++ b/src/assets/sass/print/print-general.scss
@@ -71,11 +71,7 @@ unbedingt Reihenfolge behalten
     color: blue !important;
     text-decoration: underline;
   }
-  a:not([name="context-sidebar"])
-  :not([href="#"])
-  :not(.brand)
-  :after{
-    content:" (" attr(href) ") " !important;
+  a:after{
     font-size:0.8em;
     font-weight:normal;
     font-family: sans-serif;
@@ -98,7 +94,7 @@ unbedingt Reihenfolge behalten
   .carousel-inner {overflow: visible;}
   .scroll-y, .news-feed .scroll-y {
     overflow: visible !important;
-    max-height: auto !important;
+    max-height: none !important;
   }
   .tab-content>.tab-pane {
     display: block !important;


### PR DESCRIPTION
Janiss did break the rule by splitting it on several lines.
As the same content is already added by bootstrap with a better rule, I removed the `content` part and only kept the styling. Which means the selector can be simplified.
